### PR TITLE
マイグレーションモジュールの改良

### DIFF
--- a/firmix_node/packages/auxiliaries/mz_data_migrator/example.ts
+++ b/firmix_node/packages/auxiliaries/mz_data_migrator/example.ts
@@ -1,21 +1,24 @@
-import { Db, MongoClient } from "mongodb";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { MongoClient } from "mongodb";
 import { createMzDbDataMigrator } from "./mod";
 import { IMzDbDataMigrationDefinition } from "./types";
 
 //This is an example code representing how to use maDataMigrator
 
-async function setupIndices(db: Db) {
-  //common setup function executed before migration steps.
-  //if the content of this functions has changed, it is executed once after that.
-  const userCollection = db.collection("user");
-  const projectCollection = db.collection("project");
-  await userCollection.createIndex({ userId: -1 }, { unique: true });
-  await projectCollection.createIndex({ projectId: -1 }, { unique: true });
-  await projectCollection.createIndex({ userId: 1 });
-}
-
 const migrationDefinition: IMzDbDataMigrationDefinition = {
-  commonSetup: setupIndices,
+  commonSetup: {
+    key: "001",
+    async operation(db) {
+      //common setup function executed before migration steps.
+      //this process is expected to be idempotent.
+      //(i.e. resulting the same state no matter how many times it is executed.)
+      const userCollection = db.collection("user");
+      const projectCollection = db.collection("project");
+      await userCollection.createIndex({ userId: -1 }, { unique: true });
+      await projectCollection.createIndex({ projectId: -1 }, { unique: true });
+      await projectCollection.createIndex({ userId: 1 });
+    },
+  },
   migrationsSteps: [
     {
       key: "000_initial_data",

--- a/firmix_node/packages/auxiliaries/mz_data_migrator/helpers.ts
+++ b/firmix_node/packages/auxiliaries/mz_data_migrator/helpers.ts
@@ -35,7 +35,7 @@ export namespace mzDataMigrator_internalHelpers {
     //一旦devで__vite_ssr_import_0__.を削る対応を入れるが、他の要因でもハッシュ値が合わなくなる可能性がある
     //マイグレーションスクリプトも一旦ビルドしてから実行するようにすればこの問題を回避できそう
     const hash = getTextMd5(fnStr);
-    console.log({ fnStr, hash });
+    // console.log({ fnStr, hash });
     return hash;
   }
 }

--- a/firmix_node/packages/auxiliaries/mz_data_migrator/helpers.ts
+++ b/firmix_node/packages/auxiliaries/mz_data_migrator/helpers.ts
@@ -29,13 +29,13 @@ export namespace mzDataMigrator_internalHelpers {
       .toString()
       .replaceAll(/\s+/g, " ")
       .replaceAll(/\r?\n/g, "")
-      .replaceAll(/__vite_ssr_import_[^\.]+\./g, "");
+      .replaceAll(/__vite_ssr_import_[^.]+\./g, "");
     //devで実行したときに、他のファイルからimportした変数が__vite_ssr_import_0__のような名前になり、
     //productionで実行したときと関数のテキストに差異が出てハッシュが合わなくなる問題がある
     //一旦devで__vite_ssr_import_0__.を削る対応を入れるが、他の要因でもハッシュ値が合わなくなる可能性がある
     //マイグレーションスクリプトも一旦ビルドしてから実行するようにすればこの問題を回避できそう
     const hash = getTextMd5(fnStr);
-    // console.log({ fnStr, hash });
+    console.log({ fnStr, hash });
     return hash;
   }
 }

--- a/firmix_node/packages/auxiliaries/mz_data_migrator/mod.ts
+++ b/firmix_node/packages/auxiliaries/mz_data_migrator/mod.ts
@@ -142,7 +142,7 @@ export function createMzDbDataMigrator(): IMzDbDataMigrator {
       db = _db;
       colRevision ??= await m.getDbRevisionCollection();
       await m.checkMigrationSteps(def.migrationsSteps);
-      await m.checkMigrationCommon();
+      // await m.checkMigrationCommon();  //文字列ベースのマイグレーション適用済みチェックが上手く機能しないため一旦無効化
     },
     async clearInternalMigrationRecords() {
       colRevision ??= await m.getDbRevisionCollection();

--- a/firmix_node/packages/auxiliaries/mz_data_migrator/types.ts
+++ b/firmix_node/packages/auxiliaries/mz_data_migrator/types.ts
@@ -1,5 +1,10 @@
 import { Db } from "mongodb";
 
+export type IMzDbDataMigrationCommonSetup = {
+  key: string;
+  operation(db: Db): Promise<void>;
+};
+
 export type IMzDbDataMigrationStep = {
   key: string;
   locked: boolean;
@@ -9,26 +14,40 @@ export type IMzDbDataMigrationStep = {
 export type IMzDbDataMigrationDefinition = {
   //マイグレーション管理用コレクションの名前 指定しない場合はデフォルトの名前になる
   managementCollectionName?: string;
+
   /*
-各コレクションのデータ構造の変更をここに書く
-dev環境:
- migrationKeyと関数のハッシュ値を連結したものをキーとして、これがなければ処理を実行してリビジョンを記録
-本番環境:
- migrationKeyが管理用コレクションに登録されてない場合に処理を実行してリビジョンを記録
-locked=false ..開発中でまだ処理内容が決まっていない状態
-locked=true ..処理内容が固まっている状態。フラグを立てた以降は内容を変更しない想定
-本番環境で、未適用のマイグレーションがある場合には例外を出して処理を止める
-*/
-  migrationsSteps: IMzDbDataMigrationStep[];
-  /*
-アプリに対して共通のDBセットアップ
-冪等に処理ができるインデクス作成などの処理を主にここに書く
-関数を文字列化したもののハッシュ値をとり、ハッシュ値が変わっていたら処理を実行する
-ハッシュ値は1件ずつコレクションに記録し、過去に実行したハッシュと同じ内容の処理は実行しない
+共通方針
+マイグレーションキーを持ったマイグレーションリビジョンのコレクションをDBで持ち、
+キーがこれにないなら処理を実行してリビジョンを記録する
+dev環境ではマイグレーションキーと処理関数を文字列化したもののハッシュ値をとり、ハッシュ値が変わっていたら処理を実行する
+マイグレーションキーは1件ずつコレクションに記録し、過去に実行したハッシュと同じ内容の処理は実行しない
 (新しいバージョンで最新の状態に更新されたあとに何らかの原因で古いバージョンが実行されたときに
 再度古い状態に戻されてしまうのを防ぐために、全部のリビジョンをコレックションに記録する)
 */
-  commonSetup(db: Db): Promise<void>;
+
+  /*
+アプリに対して共通のDBセットアップ
+冪等に処理ができるインデクス作成などの処理を主にここに書く
+ローカル開発:
+ migrationKeyと関数のハッシュ値を連結したものをキーとして、これがなければ処理を実行してリビジョンを記録
+マイグレーションスクリプト:
+ migrationKeyが管理用コレクションに登録されていない場合に処理を実行してリビジョンを記録
+本番環境:
+ ソースコードの最新のマイグレーション処理が未適用の場合例外を出して処理を止める
+*/
+  commonSetup: IMzDbDataMigrationCommonSetup;
+  /*
+各コレクションのデータ構造の変更をここに書く
+ローカル開発:
+ migrationKeyと関数のハッシュ値を連結したものをキーとして、これがなければ処理を実行してリビジョンを記録
+マイグレーションスクリプト:
+ migrationKeyが管理用コレクションに登録されていない場合に処理を実行してリビジョンを記録
+本番環境:
+ 未適用のマイグレーションがある場合には例外を出して処理を止める
+locked=false ..開発中でまだ処理内容が決まっていない状態
+locked=true ..処理内容が固まっている状態。フラグを立てた以降は内容を変更しない想定
+*/
+  migrationsSteps: IMzDbDataMigrationStep[];
 };
 
 export type IMzDbDataMigrator = {

--- a/firmix_node/packages/web-firmix-nextjs/Makefile
+++ b/firmix_node/packages/web-firmix-nextjs/Makefile
@@ -1,0 +1,11 @@
+dev:
+	npm run dev
+
+# debug_production_local:
+# 	npx dotenv -e .env.production.local npx remix-serve ./build/server/index.js
+
+migration_dev:
+	npx dotenv -e .env npx vite-node ./src/central/work/execute_migration.ts
+
+migration_production:
+	npx dotenv -e .env.production.local npx vite-node ./src/central/work/execute_migration.ts

--- a/firmix_node/packages/web-firmix-nextjs/src/base/app_config.ts
+++ b/firmix_node/packages/web-firmix-nextjs/src/base/app_config.ts
@@ -1,5 +1,5 @@
 export const appConfig = {
-  versionCode: "240426b nextjs",
+  versionCode: "firmix-nextjs-240426c",
   isDevelopment:
     typeof Window === "undefined"
       ? process.env.ENV_TYPE === "development"

--- a/firmix_node/packages/web-firmix-nextjs/src/central/depot/migrations.ts
+++ b/firmix_node/packages/web-firmix-nextjs/src/central/depot/migrations.ts
@@ -2,25 +2,26 @@ import { IMzDbDataMigrationDefinition } from "@mx/auxiliaries/mz_data_migrator/t
 import { Db } from "mongodb";
 import { getCollections } from "./db_core";
 
-async function setupIndices(db: Db) {
-  const { userCollection, projectCollection } = getCollections(db);
-  // userCollection.dropIndexes();
-  // projectCollection.dropIndexes();
-  await userCollection.createIndex({ userId: -1 }, { unique: true });
-  await userCollection.createIndex(
-    { loginSourceSignature: 1 },
-    { unique: true }
-  );
-  await userCollection.createIndex({ apiKey: 1 }, { unique: true });
-
-  await projectCollection.createIndex({ projectId: -1 }, { unique: true });
-  await projectCollection.createIndex({ projectGuid: 1 }, { unique: true });
-  await projectCollection.createIndex({ userId: 1 });
-  await projectCollection.createIndex({ parentProjectId: 1 });
-}
-
 export const migrationDefinition: IMzDbDataMigrationDefinition = {
-  commonSetup: setupIndices,
+  commonSetup: {
+    key: "001",
+    async operation(db: Db) {
+      const { userCollection, projectCollection } = getCollections(db);
+      // userCollection.dropIndexes();
+      // projectCollection.dropIndexes();
+      await userCollection.createIndex({ userId: -1 }, { unique: true });
+      await userCollection.createIndex(
+        { loginSourceSignature: 1 },
+        { unique: true }
+      );
+      await userCollection.createIndex({ apiKey: 1 }, { unique: true });
+
+      await projectCollection.createIndex({ projectId: -1 }, { unique: true });
+      await projectCollection.createIndex({ projectGuid: 1 }, { unique: true });
+      await projectCollection.createIndex({ userId: 1 });
+      await projectCollection.createIndex({ parentProjectId: 1 });
+    },
+  },
   migrationsSteps: [
     {
       key: "m240412_initial_data",


### PR DESCRIPTION
マイグレーションモジュールで、マイグレーション処理関数の文字列のハッシュ値を比較して処理を適用する実装になっていましたが、コードの実行環境によって関数の中身の文字列が異なるものになることが多くあり、これが上手く機能しないことがわかりました。
インデクス作成などの共通処理で、別途マイグレーションキーの文字列フィールドを設け、この値を見てマイグレーションを適用するように変更しました。