### PR TITLE
Remove utility props forwarding

### DIFF
--- a/firmix_nodejs/packages/web-firmix-nextjs/src/common_styling/create_fce.ts
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/common_styling/create_fce.ts
@@ -2,13 +2,15 @@ import { FC } from "react";
 import { BoxProps } from "../../styled-system/jsx";
 import { isCssProperty } from "./is-valid-prop";
 
-export function createFCE_Plain<P extends object>(
+export function createFCE_deprecated<P extends object>(
   baseFC: FC<P & BoxProps>
 ): FC<P & BoxProps> {
   return baseFC;
 }
 
-export function createFCE<P extends object>(baseFC: FC<P>): FC<P & BoxProps> {
+export function createFCE_EX_deprecated<P extends object>(
+  baseFC: FC<P>
+): FC<P & BoxProps> {
   return (props) => {
     const _props = props as any;
 

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/components/CommonControls.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/components/CommonControls.tsx
@@ -1,7 +1,8 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { reflectInputChecked } from "@mx/auxiliaries/utils_fe_react/form_helper";
 import Link from "next/link";
+import { css } from "../../styled-system/css";
 import { Box, HStack, styled } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 import { Input, Label, Li } from "../common_styling/utility_components";
 import { IconIconifyZ } from "./IconIconifyZ";
 
@@ -85,24 +86,26 @@ export const Nav = styled("ul", {
   },
 });
 
-const NavItemCore = createFCE<{
+const NavItemCore = createFC<{
   title: string;
   iconSpec: string;
   active?: boolean;
-}>(({ title, iconSpec, active }) => (
+  onClick?(): void;
+}>(({ title, iconSpec, active, onClick }) => (
   <HStack
     gap="2"
     fontSize="20px"
     cursor="pointer"
     fontWeight={(active && "500") || "normal"}
     _hover={{ opacity: 0.7 }}
+    onClick={onClick}
   >
-    <IconIconifyZ spec={iconSpec as any} fontSize="24px" />
+    <IconIconifyZ spec={iconSpec as any} q={css({ fontSize: "24px" })} />
     <span>{title}</span>
   </HStack>
 ));
 
-export const NavItem = createFCE<{
+export const NavItem = createFC<{
   path: string;
   title: string;
   iconSpec: string;
@@ -120,7 +123,7 @@ export const NavItem = createFCE<{
   );
 });
 
-export const NavItem_Button = createFCE<{
+export const NavItem_Button = createFC<{
   path: string;
   title: string;
   iconSpec: string;
@@ -136,7 +139,7 @@ export const NavItem_Button = createFCE<{
   );
 });
 
-export const ToggleButtonLarge = createFCE(
+export const ToggleButtonLarge = createFC(
   ({
     checked,
     setChecked,

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/components/IconIconify.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/components/IconIconify.tsx
@@ -1,11 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Box } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 type Props = {
   spec: string;
 };
 
-export const IconIconify = createFCE<Props>(({ spec }) => {
+export const IconIconify = createFC<Props>(({ spec }) => {
   return (
     <Box display="inline-flex">
       {/* @ts-ignore */}

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/components/IconIconifyZ.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/components/IconIconifyZ.tsx
@@ -1,5 +1,5 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Box } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 export const iconShapes = {
   "lucide:package": (
@@ -187,7 +187,7 @@ const iconShape_missingFallback = (
 
 type IconSpec = keyof typeof iconShapes;
 
-export const IconIconifyZ = createFCE<{ spec: IconSpec }>(({ spec }) => {
+export const IconIconifyZ = createFC<{ spec: IconSpec }>(({ spec }) => {
   const el = iconShapes[spec] ?? iconShape_missingFallback;
   const svgNode = {
     ...el,

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/layout/SideBar.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/layout/SideBar.tsx
@@ -1,11 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Stack } from "../../../styled-system/jsx";
 import { appConfig } from "../../base/app_config";
 import { useSiteContext } from "../../common/site_context";
-import { createFCE } from "../../common_styling/create_fce";
 import { Nav, NavItem, NavItem_Button } from "../../components/CommonControls";
 import { LoginUserBox } from "./LoginUserBox";
 
-export const SideBar = createFCE(() => {
+export const SideBar = createFC(() => {
   const { loginUser } = useSiteContext();
   const loggedIn = !!loginUser;
   return (

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/layout/SiteVariationSelectionPart.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/layout/SiteVariationSelectionPart.tsx
@@ -1,8 +1,8 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Center, HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { StyledA } from "../../common_styling/utility_components";
 
-const LinkButton = createFCE<{ to: string; text: string; active: boolean }>(
+const LinkButton = createFC<{ to: string; text: string; active: boolean }>(
   ({ to, text, active }) => (
     <StyledA href={to}>
       <Center
@@ -17,7 +17,7 @@ const LinkButton = createFCE<{ to: string; text: string; active: boolean }>(
   )
 );
 
-export const SiteVariationSelectionPart = createFCE<{
+export const SiteVariationSelectionPart = createFC<{
   siteVariant: "base" | "kfx";
 }>(({ siteVariant }) => {
   const baseActive = siteVariant === "base";

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/local_project/LocalProjectAssetsArea.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/local_project/LocalProjectAssetsArea.tsx
@@ -1,10 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import {
   LocalAssetBase,
   LocalAsset_Thumbnail,
   LocalDevelopmentProject,
 } from "@mx/web-firmix-nextjs/src/base/types_local_project";
+import { css } from "../../../styled-system/css";
 import { Box, HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { H3, Img } from "../../common_styling/utility_components";
 import { flexAligned } from "../../common_styling/utility_styles";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
@@ -23,14 +24,14 @@ const local = {
   },
 };
 
-const ProjectResourceHeader = createFCE(() => (
+const ProjectResourceHeader = createFC(() => (
   <H3 css={flexAligned} gap="0">
-    <IconIconifyZ spec="ph:files" fontSize="24px" />
+    <IconIconifyZ spec="ph:files" q={css({ fontSize: "24px" })} />
     <Box fontSize="20px">プロジェクトリソース</Box>
   </H3>
 ));
 
-const AssetEntry = createFCE<{
+const AssetEntry = createFC<{
   title: string;
   asset: LocalAssetBase;
   infoAdditional?: string;
@@ -46,7 +47,7 @@ const AssetEntry = createFCE<{
   return (
     <Box>
       <HStack gap="2px">
-        <IconIconifyZ spec={iconSpec} color={iconColor} />
+        <IconIconifyZ spec={iconSpec} q={css({ color: iconColor })} />
         <span>
           {title}: {asset.filePath} {infoAdditional}
         </span>
@@ -60,7 +61,7 @@ const AssetEntry = createFCE<{
   );
 });
 
-const ThumbnailBox = createFCE<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
+const ThumbnailBox = createFC<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
   <Box width="160px" height="120px">
     <Img
       src={thumbnailUrl}
@@ -72,7 +73,7 @@ const ThumbnailBox = createFCE<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
   </Box>
 ));
 
-export const LocalProjectAssetsArea = createFCE<Props>(({ project }) => {
+export const LocalProjectAssetsArea = createFC<Props>(({ project }) => {
   const { assetReadme, assetMetadata, assetThumbnail, assetFirmware } = project;
   const thumbnailInfoAdditional =
     local.extractThumbnailInfoAdditional(assetThumbnail);
@@ -93,10 +94,12 @@ export const LocalProjectAssetsArea = createFCE<Props>(({ project }) => {
       <ThumbnailBox
         thumbnailUrl={thumbnailUrl!}
         if={thumbnailUrl}
-        position="absolute"
-        top="0"
-        right="0"
-        margin="2"
+        q={css({
+          position: "absolute",
+          top: "0",
+          right: "0",
+          margin: "2",
+        })}
       />
     </Box>
   );

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/local_project/LocalProjectPageImpl.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/local_project/LocalProjectPageImpl.tsx
@@ -9,21 +9,21 @@ import {
   ProjectHeadingArea,
 } from "@mx/web-firmix-nextjs/src/features/project/ProjectHeadingArea";
 import { ProjectReadmeArea } from "@mx/web-firmix-nextjs/src/features/project/ProjectReadmeArea";
+import { css } from "../../../styled-system/css";
 import { Box, Center, Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
 import { FirmwareDownloadButtonArea } from "../project/FirmwareDownloadButton";
 
-const BuildDateTimePart = createFCE<{ timestamp: number | undefined }>(
+const BuildDateTimePart = createFC<{ timestamp: number | undefined }>(
   ({ timestamp }) => {
     const timeText = useDateTimeTextWithElapsed(timestamp ?? 0, Date.now());
     return <Box>ファームウェアビルド日時: {timeText}</Box>;
   }
 );
 
-const BlankFillerPart = createFCE(() => (
+const BlankFillerPart = createFC(() => (
   <Center flexDirection="column">
-    <IconIconifyZ spec="ph:folder-thin" fontSize="70px" />
+    <IconIconifyZ spec="ph:folder-thin" q={css({ fontSize: "70px" })} />
     <Box textAlign="center">
       ローカルプロジェクトのフォルダを
       <br />
@@ -78,13 +78,13 @@ export const LocalProjectPageImpl = createFC<{ loggedIn: boolean }>(
         <BuildDateTimePart
           timestamp={project?.assetFirmware.lastModified}
           if={project?.assetFirmware.validity === "valid"}
-          margin="0 8px"
+          q={css({ margin: "0 8px" })}
         />
         <ProjectReadmeArea
           readmeFileContent={project?.assetReadme.fileContent!}
           if={project?.assetReadme.fileContent}
         />
-        <BlankFillerPart flexGrow={1} if={!project} />
+        <BlankFillerPart q={css({ flexGrow: 1 })} if={!project} />
         <FirmwareDownloadButtonArea
           label="UF2ダウンロード"
           handler={submitEditItems}

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/ProjectHeadingArea.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/ProjectHeadingArea.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "@mx/auxiliaries/fe-deps-react";
 import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { useRepositoryDisplayInfo } from "@mx/shared/github/repository_info_helper";
 import { projectHeadingArea_parts } from "@mx/web-firmix-nextjs/src/features/project/ProjectHeadingArea_Parts";
+import { css } from "../../../styled-system/css";
 import { Stack } from "../../../styled-system/jsx";
 
 type Props = {
@@ -45,15 +46,14 @@ export const ProjectHeadingArea = createFC<Props>(
         {repositoryInfo && (
           <RepositoryInfoPart
             repositoryInfo={repositoryInfo}
-            alignSelf="flex-start"
+            q={css({ alignSelf: "flex-start" })}
           />
         )}
         {authorInfo && (
           <AuthorPart
             userName={authorInfo.userName}
             avatarUrl={authorInfo.userAvatarUrl}
-            marginLeft="2px"
-            marginBottom="8px"
+            q={css({ marginLeft: "2px", marginBottom: "8px" })}
           />
         )}
         {/* <div if={!repositoryInfo} /> */}

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/ProjectHeadingArea_Parts.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/ProjectHeadingArea_Parts.tsx
@@ -1,13 +1,14 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectRepositoryInfo } from "@mx/shared/github/types_github";
 import { FC } from "react";
+import { css } from "../../../styled-system/css";
 import { Box, BoxProps, HStack } from "../../../styled-system/jsx";
 import { styleObj_TextLinkInheritColor } from "../../common_styling/common_styles";
-import { createFCE } from "../../common_styling/create_fce";
 import { H2, H3, Img, StyledA } from "../../common_styling/utility_components";
 import { flexAligned } from "../../common_styling/utility_styles";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
 
-const ProjectTitlePart = createFCE<{
+const ProjectTitlePart = createFC<{
   projectName: string;
   variationName: string;
 }>(({ projectName, variationName }) => {
@@ -16,8 +17,7 @@ const ProjectTitlePart = createFCE<{
       <H2 css={flexAligned} gap="2px" fontSize="32px">
         <IconIconifyZ
           spec="icon-park-twotone:chip"
-          fontSize="36px"
-          marginTop="3px"
+          q={css({ fontSize: "36px", marginTop: "3px" })}
         />
         <span>{projectName}</span>
       </H2>
@@ -51,7 +51,7 @@ const ProjectTagsList: FC<BoxProps & { tags: string[] }> = ({
   );
 };
 
-const RepositoryInfoPart = createFCE<{
+const RepositoryInfoPart = createFC<{
   repositoryInfo: ProjectRepositoryInfo;
 }>(({ repositoryInfo }) => {
   return (
@@ -61,14 +61,17 @@ const RepositoryInfoPart = createFCE<{
       rel="noreferrer"
     >
       <HStack gap="1px" css={styleObj_TextLinkInheritColor}>
-        <IconIconifyZ spec="mdi:github" fontSize="30px" marginTop="4px" />
+        <IconIconifyZ
+          spec="mdi:github"
+          q={css({ fontSize: "30px", marginTop: "4px" })}
+        />
         <Box fontSize="18px">{repositoryInfo.repositoryProjectPath}</Box>
       </HStack>
     </StyledA>
   );
 });
 
-const AuthorPart = createFCE<{ userName: string; avatarUrl: string }>(
+const AuthorPart = createFC<{ userName: string; avatarUrl: string }>(
   ({ userName, avatarUrl }) => {
     return (
       <HStack gap="4px">

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/project_common_parts.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project/project_common_parts.tsx
@@ -1,9 +1,10 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
+import { css } from "../../../styled-system/css";
 import { HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { StyledLink } from "../../common_styling/utility_components";
 import { IconIconify } from "../../components/IconIconify";
 
-const ProjectLinkCommon = createFCE<{
+const ProjectLinkCommon = createFC<{
   pagePath: string;
   iconSpec: string;
   iconYOffset: string;
@@ -17,13 +18,13 @@ const ProjectLinkCommon = createFCE<{
       fontSize={smaller ? "0.9em" : "1.0em"}
       _hover={{ textDecoration: "underline" }}
     >
-      <IconIconify spec={iconSpec} marginTop={iconYOffset} />
+      <IconIconify spec={iconSpec} q={css({ marginTop: iconYOffset })} />
       <span>{text}</span>
     </HStack>
   </StyledLink>
 ));
 
-export const LinkChildProjectListPage = createFCE<{
+export const LinkChildProjectListPage = createFC<{
   project: { projectId: string; numChildProjects: number };
   smaller?: boolean;
 }>(({ project, smaller }) => {
@@ -40,7 +41,7 @@ export const LinkChildProjectListPage = createFCE<{
   );
 });
 
-export const LinkParentProjectPage = createFCE<{
+export const LinkParentProjectPage = createFC<{
   projectId: string;
   smaller?: boolean;
 }>(({ projectId, smaller }) => {

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_detail/ProjectDetailPageImpl.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_detail/ProjectDetailPageImpl.tsx
@@ -12,6 +12,7 @@ import {
 import { ProjectHeadingArea } from "@mx/web-firmix-nextjs/src/features/project/ProjectHeadingArea";
 import { ProjectReadmeArea } from "@mx/web-firmix-nextjs/src/features/project/ProjectReadmeArea";
 import { ProjectOperationPart } from "@mx/web-firmix-nextjs/src/features/project_detail/ProjectOperationPart";
+import { css } from "../../../styled-system/css";
 import { Box } from "../../../styled-system/jsx";
 import { firmixPresenter_firmwarePatching } from "../../cardinal/firmix_presenter_firmware_patching/mod";
 import { FirmwareDownloadButtonArea } from "../project/FirmwareDownloadButton";
@@ -79,14 +80,18 @@ export const ProjectDetailPageImpl = createFC<Props>(({ project }: Props) => {
         <LinkChildProjectListPage
           project={project}
           if={project.numChildProjects > 0}
-          marginTop="8px"
-          marginLeft="3px"
+          q={css({
+            marginTop: "8px",
+            marginLeft: "3px",
+          })}
         />
         <LinkParentProjectPage
           projectId={project.parentProjectId}
           if={!!project.parentProjectId}
-          marginTop="8px"
-          marginLeft="3px"
+          q={css({
+            marginTop: "8px",
+            marginLeft: "3px",
+          })}
         />
       </Box>
       <ProjectReadmeArea readmeFileContent={project.readmeFileContent} />

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_detail/ProjectOperationPart.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_detail/ProjectOperationPart.tsx
@@ -1,12 +1,12 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { rpcClient } from "@mx/web-firmix-nextjs/src/common/rpc_client";
 import { Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import {
   ButtonSmall,
   ToggleButtonLarge,
 } from "../../components/CommonControls";
 
-export const ProjectOperationPart = createFCE<{
+export const ProjectOperationPart = createFC<{
   projectId: string;
   published: boolean;
   automated: boolean;

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_list/ProjectListItemCard.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/features/project_list/ProjectListItemCard.tsx
@@ -2,8 +2,8 @@ import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectListItemDto } from "@mx/web-firmix-nextjs/src/base/types_dto";
 import { LinkChildProjectListPage } from "@mx/web-firmix-nextjs/src/features/project/project_common_parts";
 import { projectHeadingArea_parts } from "@mx/web-firmix-nextjs/src/features/project/ProjectHeadingArea_Parts";
+import { css } from "../../../styled-system/css";
 import { Box, Flex, HStack, Spacer, Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { prefab } from "../../common_styling/prefab";
 import { H3, H4, Img } from "../../common_styling/utility_components";
 import { Card, LinkButton } from "../../components/CommonControls";
@@ -13,7 +13,7 @@ type Props = {
   showPublicity: boolean;
 };
 
-const ThumbnailBox = createFCE<{ imageUrl: string }>(({ imageUrl }) => (
+const ThumbnailBox = createFC<{ imageUrl: string }>(({ imageUrl }) => (
   <Box width="200px" aspectRatio={1.3333}>
     <Img
       src={imageUrl}
@@ -29,7 +29,7 @@ const ProjectNameLabel = prefab(<H3 fontSize="22px" />);
 
 const VariationNameLabel = prefab(<H4 fontSize="18px" />);
 
-const AuthorInfo = createFCE<{ userName: string; avatarUrl: string }>(
+const AuthorInfo = createFC<{ userName: string; avatarUrl: string }>(
   ({ userName, avatarUrl }) => (
     <HStack gap={1}>
       <Img src={avatarUrl} alt="avatar" width="24px" />
@@ -38,7 +38,7 @@ const AuthorInfo = createFCE<{ userName: string; avatarUrl: string }>(
   )
 );
 
-const PublicityLabel = createFCE<{ published: boolean }>(({ published }) => (
+const PublicityLabel = createFC<{ published: boolean }>(({ published }) => (
   <Box fontSize="15px" color={published ? "#7ca" : "#888"}>
     {published ? "公開中" : "ドラフト"}
   </Box>
@@ -53,8 +53,10 @@ export const ProjectListItemCard = createFC<Props>(
         <Flex gap={4}>
           <ThumbnailBox
             imageUrl={project.thumbnailUrl}
-            alignSelf="flex-start"
-            flexShrink={0}
+            q={css({
+              alignSelf: "flex-start",
+              flexShrink: 0,
+            })}
           />
           <Stack flexGrow={1} gap={1}>
             <HStack gap={5} alignItems="flex-start">
@@ -66,7 +68,7 @@ export const ProjectListItemCard = createFC<Props>(
               <PublicityLabel
                 if={showPublicity}
                 published={project.published}
-                flexShrink={0}
+                q={css({ flexShrink: 0 })}
               />
               <LinkButton
                 href={detailPagePath}
@@ -83,8 +85,7 @@ export const ProjectListItemCard = createFC<Props>(
               project={project}
               if={project.numChildProjects > 0}
               smaller
-              marginLeft="3px"
-              alignSelf="flex-start"
+              q={css({ marginLeft: "3px", alignSelf: "flex-start" })}
             />
             <Spacer />
             <HStack alignItems="flex-end">

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/screens/MainLayout.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/screens/MainLayout.tsx
@@ -1,17 +1,21 @@
 "use client";
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ReactNode } from "react";
+import { css } from "../../styled-system/css";
 import { Box, Flex, HStack, Spacer } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 import { H1 } from "../common_styling/utility_components";
 import { flexAligned } from "../common_styling/utility_styles";
 import { IconIconifyZ } from "../components/IconIconifyZ";
 import { SideBar } from "../features/layout/SideBar";
 import { SiteVariationSelectionPart } from "../features/layout/SiteVariationSelectionPart";
 
-const SiteTitle = createFCE(() => {
+const SiteTitle = createFC(() => {
   return (
     <HStack gap="2px" color="var(--cl-top-bar-text)">
-      <IconIconifyZ spec="mdi:chip" fontSize="44px" marginTop="3px" />
+      <IconIconifyZ
+        spec="mdi:chip"
+        q={css({ fontSize: "44px", marginTop: "3px" })}
+      />
       <H1 css={flexAligned} gap={2}>
         <Box fontSize="36px" fontWeight="bold">
           Firmix
@@ -24,7 +28,7 @@ const SiteTitle = createFCE(() => {
   );
 });
 
-const TopBar = createFCE(() => (
+const TopBar = createFC(() => (
   <HStack
     gap={0}
     padding="0 12px"
@@ -37,14 +41,16 @@ const TopBar = createFCE(() => (
   </HStack>
 ));
 
-const MainRow = createFCE<{ children: ReactNode }>(({ children }) => {
+const MainRow = createFC<{ children: ReactNode }>(({ children }) => {
   return (
     <Flex>
       <SideBar
-        position="sticky"
-        top="60px"
-        height="calc(100vh - 60px)"
-        flexShrink={0}
+        q={css({
+          position: "sticky",
+          top: "60px",
+          height: "calc(100vh - 60px)",
+          flexShrink: "0",
+        })}
       />
       <Flex flexGrow={1} justifyContent="center">
         <Box flexGrow={1} maxWidth="800px">
@@ -55,7 +61,7 @@ const MainRow = createFCE<{ children: ReactNode }>(({ children }) => {
   );
 });
 
-export const MainLayout = createFCE(({ children }: { children: ReactNode }) => {
+export const MainLayout = createFC(({ children }: { children: ReactNode }) => {
   return (
     <Flex
       flexDirection="column"
@@ -64,13 +70,15 @@ export const MainLayout = createFCE(({ children }: { children: ReactNode }) => {
       color="var(--cl-foreground-text)"
     >
       <TopBar
-        position="sticky"
-        width="100%"
-        top={0}
-        zIndex={100}
-        flexShrink={0}
+        q={css({
+          position: "sticky",
+          width: "100%",
+          top: 0,
+          zIndex: 100,
+          flexShrink: 0,
+        })}
       />
-      <MainRow flexGrow={1} children={children} />
+      <MainRow q={css({ flexGrow: 1 })} children={children} />
     </Flex>
   );
 });

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/screens/ProjectListPage.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/screens/ProjectListPage.tsx
@@ -1,15 +1,15 @@
 "use client";
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectListItemDto } from "@mx/web-firmix-nextjs/src/base/types_dto";
 import { ProjectListItemCard } from "@mx/web-firmix-nextjs/src/features/project_list/ProjectListItemCard";
 import { Stack } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 type Props = {
   projects: ProjectListItemDto[];
   showPublicity: boolean;
 };
 
-export const ProjectListPage = createFCE<Props>(
+export const ProjectListPage = createFC<Props>(
   ({ projects, showPublicity }) => {
     return (
       <Stack gap={3} padding="16px 0">

--- a/firmix_nodejs/packages/web-firmix/app/central/depot/migrations.ts
+++ b/firmix_nodejs/packages/web-firmix/app/central/depot/migrations.ts
@@ -2,25 +2,26 @@ import { IMzDbDataMigrationDefinition } from "@mx/auxiliaries/mz_data_migrator/t
 import { Db } from "mongodb";
 import { getCollections } from "./db_core";
 
-async function setupIndices(db: Db) {
-  const { userCollection, projectCollection } = getCollections(db);
-  // userCollection.dropIndexes();
-  // projectCollection.dropIndexes();
-  await userCollection.createIndex({ userId: -1 }, { unique: true });
-  await userCollection.createIndex(
-    { loginSourceSignature: 1 },
-    { unique: true }
-  );
-  await userCollection.createIndex({ apiKey: 1 }, { unique: true });
-
-  await projectCollection.createIndex({ projectId: -1 }, { unique: true });
-  await projectCollection.createIndex({ projectGuid: 1 }, { unique: true });
-  await projectCollection.createIndex({ userId: 1 });
-  await projectCollection.createIndex({ parentProjectId: 1 });
-}
-
 export const migrationDefinition: IMzDbDataMigrationDefinition = {
-  commonSetup: setupIndices,
+  commonSetup: {
+    key: "001",
+    async operation(db: Db) {
+      const { userCollection, projectCollection } = getCollections(db);
+      // userCollection.dropIndexes();
+      // projectCollection.dropIndexes();
+      await userCollection.createIndex({ userId: -1 }, { unique: true });
+      await userCollection.createIndex(
+        { loginSourceSignature: 1 },
+        { unique: true }
+      );
+      await userCollection.createIndex({ apiKey: 1 }, { unique: true });
+
+      await projectCollection.createIndex({ projectId: -1 }, { unique: true });
+      await projectCollection.createIndex({ projectGuid: 1 }, { unique: true });
+      await projectCollection.createIndex({ userId: 1 });
+      await projectCollection.createIndex({ parentProjectId: 1 });
+    },
+  },
   migrationsSteps: [
     {
       key: "m240412_initial_data",

--- a/firmix_nodejs/packages/web-firmix/app/common_styling/create_fce.ts
+++ b/firmix_nodejs/packages/web-firmix/app/common_styling/create_fce.ts
@@ -2,13 +2,15 @@ import { FC } from "react";
 import { BoxProps } from "../../styled-system/jsx";
 import { isCssProperty } from "./is-valid-prop";
 
-export function createFCE_Plain<P extends object>(
+export function createFCE_Deprecated<P extends object>(
   baseFC: FC<P & BoxProps>
 ): FC<P & BoxProps> {
   return baseFC;
 }
 
-export function createFCE<P extends object>(baseFC: FC<P>): FC<P & BoxProps> {
+export function createFCE_EX_Deprecated<P extends object>(
+  baseFC: FC<P>
+): FC<P & BoxProps> {
   return (props) => {
     const _props = props as any;
 

--- a/firmix_nodejs/packages/web-firmix/app/components/CommonControls.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/components/CommonControls.tsx
@@ -1,7 +1,8 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { reflectInputChecked } from "@mx/auxiliaries/utils_fe_react/form_helper";
 import { Link } from "@remix-run/react";
+import { css } from "../../styled-system/css";
 import { Box, HStack, styled } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 import { Input, Label, Li } from "../common_styling/utility_components";
 import { IconIconifyZ } from "./IconIconifyZ";
 
@@ -85,24 +86,26 @@ export const Nav = styled("ul", {
   },
 });
 
-const NavItemCore = createFCE<{
+const NavItemCore = createFC<{
   title: string;
   iconSpec: string;
   active?: boolean;
-}>(({ title, iconSpec, active }) => (
+  onClick?(): void;
+}>(({ title, iconSpec, active, onClick }) => (
   <HStack
     gap="2"
     fontSize="20px"
     cursor="pointer"
     fontWeight={(active && "500") || "normal"}
     _hover={{ opacity: 0.7 }}
+    onClick={onClick}
   >
-    <IconIconifyZ spec={iconSpec as any} fontSize="24px" />
+    <IconIconifyZ spec={iconSpec as any} q={css({ fontSize: "24px" })} />
     <span>{title}</span>
   </HStack>
 ));
 
-export const NavItem = createFCE<{
+export const NavItem = createFC<{
   path: string;
   title: string;
   iconSpec: string;
@@ -120,7 +123,7 @@ export const NavItem = createFCE<{
   );
 });
 
-export const NavItem_Button = createFCE<{
+export const NavItem_Button = createFC<{
   path: string;
   title: string;
   iconSpec: string;
@@ -136,7 +139,7 @@ export const NavItem_Button = createFCE<{
   );
 });
 
-export const ToggleButtonLarge = createFCE(
+export const ToggleButtonLarge = createFC(
   ({
     checked,
     setChecked,

--- a/firmix_nodejs/packages/web-firmix/app/components/IconIconify.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/components/IconIconify.tsx
@@ -1,11 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Box } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 type Props = {
   spec: string;
 };
 
-export const IconIconify = createFCE<Props>(({ spec }) => {
+export const IconIconify = createFC<Props>(({ spec }) => {
   return (
     <Box display="inline-flex">
       {/* @ts-ignore */}

--- a/firmix_nodejs/packages/web-firmix/app/components/IconIconifyZ.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/components/IconIconifyZ.tsx
@@ -1,5 +1,5 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Box } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 export const iconShapes = {
   "lucide:package": (
@@ -187,7 +187,7 @@ const iconShape_missingFallback = (
 
 type IconSpec = keyof typeof iconShapes;
 
-export const IconIconifyZ = createFCE<{ spec: IconSpec }>(({ spec }) => {
+export const IconIconifyZ = createFC<{ spec: IconSpec }>(({ spec }) => {
   const el = iconShapes[spec] ?? iconShape_missingFallback;
   const svgNode = {
     ...el,

--- a/firmix_nodejs/packages/web-firmix/app/features/layout/SideBar.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/layout/SideBar.tsx
@@ -1,11 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { appConfig } from "@mx/web-firmix/app/base/app_config";
 import { useSiteContext } from "@mx/web-firmix/app/common/site_context";
 import { LoginUserBox } from "@mx/web-firmix/app/features/layout/LoginUserBox";
 import { Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { Nav, NavItem, NavItem_Button } from "../../components/CommonControls";
 
-export const SideBar = createFCE(() => {
+export const SideBar = createFC(() => {
   const { loginUser } = useSiteContext();
   const loggedIn = !!loginUser;
   return (

--- a/firmix_nodejs/packages/web-firmix/app/features/layout/SiteVariationSelectionPart.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/layout/SiteVariationSelectionPart.tsx
@@ -1,8 +1,8 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { Center, HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { StyledA } from "../../common_styling/utility_components";
 
-const LinkButton = createFCE<{ to: string; text: string; active: boolean }>(
+const LinkButton = createFC<{ to: string; text: string; active: boolean }>(
   ({ to, text, active }) => (
     <StyledA href={to}>
       <Center
@@ -17,7 +17,7 @@ const LinkButton = createFCE<{ to: string; text: string; active: boolean }>(
   )
 );
 
-export const SiteVariationSelectionPart = createFCE<{
+export const SiteVariationSelectionPart = createFC<{
   siteVariant: "base" | "kfx";
 }>(({ siteVariant }) => {
   const baseActive = siteVariant === "base";

--- a/firmix_nodejs/packages/web-firmix/app/features/local_project/LocalProjectAssetsArea.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/local_project/LocalProjectAssetsArea.tsx
@@ -1,10 +1,11 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import {
   LocalAssetBase,
   LocalAsset_Thumbnail,
   LocalDevelopmentProject,
 } from "@mx/web-firmix/app/base/types_local_project";
+import { css } from "../../../styled-system/css";
 import { Box, HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { H3, Img } from "../../common_styling/utility_components";
 import { flexAligned } from "../../common_styling/utility_styles";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
@@ -23,14 +24,14 @@ const local = {
   },
 };
 
-const ProjectResourceHeader = createFCE(() => (
+const ProjectResourceHeader = createFC(() => (
   <H3 css={flexAligned} gap="0">
-    <IconIconifyZ spec="ph:files" fontSize="24px" />
+    <IconIconifyZ spec="ph:files" q={css({ fontSize: "24px" })} />
     <Box fontSize="20px">プロジェクトリソース</Box>
   </H3>
 ));
 
-const AssetEntry = createFCE<{
+const AssetEntry = createFC<{
   title: string;
   asset: LocalAssetBase;
   infoAdditional?: string;
@@ -46,7 +47,7 @@ const AssetEntry = createFCE<{
   return (
     <Box>
       <HStack gap="2px">
-        <IconIconifyZ spec={iconSpec} color={iconColor} />
+        <IconIconifyZ spec={iconSpec} q={css({ color: iconColor })} />
         <span>
           {title}: {asset.filePath} {infoAdditional}
         </span>
@@ -60,7 +61,7 @@ const AssetEntry = createFCE<{
   );
 });
 
-const ThumbnailBox = createFCE<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
+const ThumbnailBox = createFC<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
   <Box width="160px" height="120px">
     <Img
       src={thumbnailUrl}
@@ -72,7 +73,7 @@ const ThumbnailBox = createFCE<{ thumbnailUrl: string }>(({ thumbnailUrl }) => (
   </Box>
 ));
 
-export const LocalProjectAssetsArea = createFCE<Props>(({ project }) => {
+export const LocalProjectAssetsArea = createFC<Props>(({ project }) => {
   const { assetReadme, assetMetadata, assetThumbnail, assetFirmware } = project;
   const thumbnailInfoAdditional =
     local.extractThumbnailInfoAdditional(assetThumbnail);
@@ -93,10 +94,12 @@ export const LocalProjectAssetsArea = createFCE<Props>(({ project }) => {
       <ThumbnailBox
         thumbnailUrl={thumbnailUrl!}
         if={thumbnailUrl}
-        position="absolute"
-        top="0"
-        right="0"
-        margin="2"
+        q={css({
+          position: "absolute",
+          top: "0",
+          right: "0",
+          margin: "2",
+        })}
       />
     </Box>
   );

--- a/firmix_nodejs/packages/web-firmix/app/features/local_project/LocalProjectPageImpl.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/local_project/LocalProjectPageImpl.tsx
@@ -9,21 +9,21 @@ import {
   ProjectHeadingArea,
 } from "@mx/web-firmix/app/features/project/ProjectHeadingArea";
 import { ProjectReadmeArea } from "@mx/web-firmix/app/features/project/ProjectReadmeArea";
+import { css } from "../../../styled-system/css";
 import { Box, Center, Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
 import { FirmwareDownloadButtonArea } from "../project/FirmwareDownloadButton";
 
-const BuildDateTimePart = createFCE<{ timestamp: number | undefined }>(
+const BuildDateTimePart = createFC<{ timestamp: number | undefined }>(
   ({ timestamp }) => {
     const timeText = useDateTimeTextWithElapsed(timestamp ?? 0, Date.now());
     return <Box>ファームウェアビルド日時: {timeText}</Box>;
   }
 );
 
-const BlankFillerPart = createFCE(() => (
+const BlankFillerPart = createFC(() => (
   <Center flexDirection="column">
-    <IconIconifyZ spec="ph:folder-thin" fontSize="70px" />
+    <IconIconifyZ spec="ph:folder-thin" q={css({ fontSize: "70px" })} />
     <Box textAlign="center">
       ローカルプロジェクトのフォルダを
       <br />
@@ -78,13 +78,13 @@ export const LocalProjectPageImpl = createFC<{ loggedIn: boolean }>(
         <BuildDateTimePart
           timestamp={project?.assetFirmware.lastModified}
           if={project?.assetFirmware.validity === "valid"}
-          margin="0 8px"
+          q={css({ margin: "0 8px" })}
         />
         <ProjectReadmeArea
           readmeFileContent={project?.assetReadme.fileContent!}
           if={project?.assetReadme.fileContent}
         />
-        <BlankFillerPart flexGrow={1} if={!project} />
+        <BlankFillerPart q={css({ flexGrow: 1 })} if={!project} />
         <FirmwareDownloadButtonArea
           label="UF2ダウンロード"
           handler={submitEditItems}

--- a/firmix_nodejs/packages/web-firmix/app/features/project/ProjectHeadingArea.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project/ProjectHeadingArea.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "@mx/auxiliaries/fe-deps-react";
 import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { useRepositoryDisplayInfo } from "@mx/shared/github/repository_info_helper";
 import { projectHeadingArea_parts } from "@mx/web-firmix/app/features/project/ProjectHeadingArea_Parts";
+import { css } from "../../../styled-system/css";
 import { Stack } from "../../../styled-system/jsx";
 
 type Props = {
@@ -49,8 +50,10 @@ export const ProjectHeadingArea = createFC<Props>(
           <AuthorPart
             userName={authorInfo.userName}
             avatarUrl={authorInfo.userAvatarUrl}
-            marginLeft="2px"
-            marginBottom="8px"
+            q={css({
+              marginLeft: "2px",
+              marginTop: "8px",
+            })}
           />
         )}
         {/* <div if={!repositoryInfo} /> */}

--- a/firmix_nodejs/packages/web-firmix/app/features/project/ProjectHeadingArea_Parts.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project/ProjectHeadingArea_Parts.tsx
@@ -1,13 +1,14 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectRepositoryInfo } from "@mx/shared/github/types_github";
 import { FC } from "react";
+import { css } from "../../../styled-system/css";
 import { Box, BoxProps, HStack } from "../../../styled-system/jsx";
 import { styleObj_TextLinkInheritColor } from "../../common_styling/common_styles";
-import { createFCE } from "../../common_styling/create_fce";
 import { H2, H3, Img, StyledA } from "../../common_styling/utility_components";
 import { flexAligned } from "../../common_styling/utility_styles";
 import { IconIconifyZ } from "../../components/IconIconifyZ";
 
-const ProjectTitlePart = createFCE<{
+const ProjectTitlePart = createFC<{
   projectName: string;
   variationName: string;
 }>(({ projectName, variationName }) => {
@@ -16,8 +17,7 @@ const ProjectTitlePart = createFCE<{
       <H2 css={flexAligned} gap="2px" fontSize="32px">
         <IconIconifyZ
           spec="icon-park-twotone:chip"
-          fontSize="36px"
-          marginTop="3px"
+          q={css({ fontSize: "36px", marginTop: "3px" })}
         />
         <span>{projectName}</span>
       </H2>
@@ -51,7 +51,7 @@ const ProjectTagsList: FC<BoxProps & { tags: string[] }> = ({
   );
 };
 
-const RepositoryInfoPart = createFCE<{
+const RepositoryInfoPart = createFC<{
   repositoryInfo: ProjectRepositoryInfo;
 }>(({ repositoryInfo }) => {
   return (
@@ -61,14 +61,17 @@ const RepositoryInfoPart = createFCE<{
       rel="noreferrer"
     >
       <HStack gap="1px" css={styleObj_TextLinkInheritColor}>
-        <IconIconifyZ spec="mdi:github" fontSize="30px" marginTop="4px" />
+        <IconIconifyZ
+          spec="mdi:github"
+          q={css({ fontSize: "30px", marginTop: "4px" })}
+        />
         <Box fontSize="18px">{repositoryInfo.repositoryProjectPath}</Box>
       </HStack>
     </StyledA>
   );
 });
 
-const AuthorPart = createFCE<{ userName: string; avatarUrl: string }>(
+const AuthorPart = createFC<{ userName: string; avatarUrl: string }>(
   ({ userName, avatarUrl }) => {
     return (
       <HStack gap="4px">

--- a/firmix_nodejs/packages/web-firmix/app/features/project/project_common_parts.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project/project_common_parts.tsx
@@ -1,9 +1,10 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
+import { css } from "../../../styled-system/css";
 import { HStack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { StyledLink } from "../../common_styling/utility_components";
 import { IconIconify } from "../../components/IconIconify";
 
-const ProjectLinkCommon = createFCE<{
+const ProjectLinkCommon = createFC<{
   pagePath: string;
   iconSpec: string;
   iconYOffset: string;
@@ -17,13 +18,13 @@ const ProjectLinkCommon = createFCE<{
       fontSize={smaller ? "0.9em" : "1.0em"}
       _hover={{ textDecoration: "underline" }}
     >
-      <IconIconify spec={iconSpec} marginTop={iconYOffset} />
+      <IconIconify spec={iconSpec} q={css({ marginTop: iconYOffset })} />
       <span>{text}</span>
     </HStack>
   </StyledLink>
 ));
 
-export const LinkChildProjectListPage = createFCE<{
+export const LinkChildProjectListPage = createFC<{
   project: { projectId: string; numChildProjects: number };
   smaller?: boolean;
 }>(({ project, smaller }) => {
@@ -40,7 +41,7 @@ export const LinkChildProjectListPage = createFCE<{
   );
 });
 
-export const LinkParentProjectPage = createFCE<{
+export const LinkParentProjectPage = createFC<{
   projectId: string;
   smaller?: boolean;
 }>(({ projectId, smaller }) => {

--- a/firmix_nodejs/packages/web-firmix/app/features/project_detail/ProjectDetailPageImpl.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project_detail/ProjectDetailPageImpl.tsx
@@ -12,6 +12,7 @@ import {
 import { ProjectHeadingArea } from "@mx/web-firmix/app/features/project/ProjectHeadingArea";
 import { ProjectReadmeArea } from "@mx/web-firmix/app/features/project/ProjectReadmeArea";
 import { ProjectOperationPart } from "@mx/web-firmix/app/features/project_detail/ProjectOperationPart";
+import { css } from "../../../styled-system/css";
 import { Box } from "../../../styled-system/jsx";
 import { firmixPresenter_firmwarePatching } from "../../cardinal/firmix_presenter_firmware_patching/mod";
 import { FirmwareDownloadButtonArea } from "../project/FirmwareDownloadButton";
@@ -79,14 +80,18 @@ export const ProjectDetailPageImpl = createFC<Props>(({ project }: Props) => {
         <LinkChildProjectListPage
           project={project}
           if={project.numChildProjects > 0}
-          marginTop="8px"
-          marginLeft="3px"
+          q={css({
+            marginTop: "8px",
+            marginLeft: "3px",
+          })}
         />
         <LinkParentProjectPage
           projectId={project.parentProjectId}
           if={!!project.parentProjectId}
-          marginTop="8px"
-          marginLeft="3px"
+          q={css({
+            marginTop: "8px",
+            marginLeft: "3px",
+          })}
         />
       </Box>
       <ProjectReadmeArea readmeFileContent={project.readmeFileContent} />

--- a/firmix_nodejs/packages/web-firmix/app/features/project_detail/ProjectOperationPart.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project_detail/ProjectOperationPart.tsx
@@ -1,12 +1,12 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { rpcClient } from "@mx/web-firmix/app/common/rpc_client";
 import { Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import {
   ButtonSmall,
   ToggleButtonLarge,
 } from "../../components/CommonControls";
 
-export const ProjectOperationPart = createFCE<{
+export const ProjectOperationPart = createFC<{
   projectId: string;
   published: boolean;
   automated: boolean;

--- a/firmix_nodejs/packages/web-firmix/app/features/project_list/ProjectListItemCard.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/features/project_list/ProjectListItemCard.tsx
@@ -2,8 +2,8 @@ import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectListItemDto } from "@mx/web-firmix/app/base/types_dto";
 import { LinkChildProjectListPage } from "@mx/web-firmix/app/features/project/project_common_parts";
 import { projectHeadingArea_parts } from "@mx/web-firmix/app/features/project/ProjectHeadingArea_Parts";
+import { css } from "../../../styled-system/css";
 import { Box, Flex, HStack, Spacer, Stack } from "../../../styled-system/jsx";
-import { createFCE } from "../../common_styling/create_fce";
 import { prefab } from "../../common_styling/prefab";
 import { H3, H4, Img } from "../../common_styling/utility_components";
 import { Card, LinkButton } from "../../components/CommonControls";
@@ -13,7 +13,7 @@ type Props = {
   showPublicity: boolean;
 };
 
-const ThumbnailBox = createFCE<{ imageUrl: string }>(({ imageUrl }) => (
+const ThumbnailBox = createFC<{ imageUrl: string }>(({ imageUrl }) => (
   <Box width="200px" aspectRatio={1.3333}>
     <Img
       src={imageUrl}
@@ -29,7 +29,7 @@ const ProjectNameLabel = prefab(<H3 fontSize="22px" />);
 
 const VariationNameLabel = prefab(<H4 fontSize="18px" />);
 
-const AuthorInfo = createFCE<{ userName: string; avatarUrl: string }>(
+const AuthorInfo = createFC<{ userName: string; avatarUrl: string }>(
   ({ userName, avatarUrl }) => (
     <HStack gap={1}>
       <Img src={avatarUrl} alt="avatar" width="24px" />
@@ -38,7 +38,7 @@ const AuthorInfo = createFCE<{ userName: string; avatarUrl: string }>(
   )
 );
 
-const PublicityLabel = createFCE<{ published: boolean }>(({ published }) => (
+const PublicityLabel = createFC<{ published: boolean }>(({ published }) => (
   <Box fontSize="15px" color={published ? "#7ca" : "#888"}>
     {published ? "公開中" : "ドラフト"}
   </Box>
@@ -53,8 +53,7 @@ export const ProjectListItemCard = createFC<Props>(
         <Flex gap={4}>
           <ThumbnailBox
             imageUrl={project.thumbnailUrl}
-            alignSelf="flex-start"
-            flexShrink={0}
+            q={css({ alignSelf: "flex-start", flexShrink: 0 })}
           />
           <Stack flexGrow={1} gap={1}>
             <HStack gap={5} alignItems="flex-start">
@@ -66,7 +65,7 @@ export const ProjectListItemCard = createFC<Props>(
               <PublicityLabel
                 if={showPublicity}
                 published={project.published}
-                flexShrink={0}
+                q={css({ flexShrink: 0 })}
               />
               <LinkButton
                 to={detailPagePath}
@@ -83,7 +82,7 @@ export const ProjectListItemCard = createFC<Props>(
               project={project}
               if={project.numChildProjects > 0}
               smaller
-              marginLeft="3px"
+              q={css({ marginLeft: "3px" })}
             />
             <Spacer />
             <HStack alignItems="flex-end">

--- a/firmix_nodejs/packages/web-firmix/app/islands/MainLayout.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/islands/MainLayout.tsx
@@ -1,16 +1,20 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { SideBar } from "@mx/web-firmix/app/features/layout/SideBar";
 import { ReactNode } from "react";
+import { css } from "../../styled-system/css";
 import { Box, Flex, HStack, Spacer } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 import { H1 } from "../common_styling/utility_components";
 import { flexAligned } from "../common_styling/utility_styles";
 import { IconIconifyZ } from "../components/IconIconifyZ";
 import { SiteVariationSelectionPart } from "../features/layout/SiteVariationSelectionPart";
 
-const SiteTitle = createFCE(() => {
+const SiteTitle = createFC(() => {
   return (
     <HStack gap="2px" color="var(--cl-top-bar-text)">
-      <IconIconifyZ spec="mdi:chip" fontSize="44px" marginTop="3px" />
+      <IconIconifyZ
+        spec="mdi:chip"
+        q={css({ fontSize: "44px", marginTop: "3px" })}
+      />
       <H1 css={flexAligned} gap={2}>
         <Box fontSize="36px" fontWeight="bold">
           Firmix
@@ -23,7 +27,7 @@ const SiteTitle = createFCE(() => {
   );
 });
 
-const TopBar = createFCE(() => (
+const TopBar = createFC(() => (
   <HStack
     gap={0}
     padding="0 12px"
@@ -36,14 +40,16 @@ const TopBar = createFCE(() => (
   </HStack>
 ));
 
-const MainRow = createFCE<{ children: ReactNode }>(({ children }) => {
+const MainRow = createFC<{ children: ReactNode }>(({ children }) => {
   return (
     <Flex>
       <SideBar
-        position="sticky"
-        top="60px"
-        height="calc(100vh - 60px)"
-        flexShrink={0}
+        q={css({
+          position: "sticky",
+          top: "60px",
+          height: "calc(100vh - 60px)",
+          flexShrink: "0",
+        })}
       />
       <Flex flexGrow={1} justifyContent="center">
         <Box flexGrow={1} maxWidth="800px">
@@ -54,7 +60,7 @@ const MainRow = createFCE<{ children: ReactNode }>(({ children }) => {
   );
 });
 
-export const MainLayout = createFCE(({ children }: { children: ReactNode }) => {
+export const MainLayout = createFC(({ children }: { children: ReactNode }) => {
   return (
     <Flex
       flexDirection="column"
@@ -63,13 +69,15 @@ export const MainLayout = createFCE(({ children }: { children: ReactNode }) => {
       color="var(--cl-foreground-text)"
     >
       <TopBar
-        position="sticky"
-        width="100%"
-        top={0}
-        zIndex={100}
-        flexShrink={0}
+        q={css({
+          position: "sticky",
+          width: "100%",
+          top: "0",
+          zIndex: "100",
+          flexShrink: "0",
+        })}
       />
-      <MainRow flexGrow={1} children={children} />
+      <MainRow children={children} q={css({ flexGrow: 1 })} />
     </Flex>
   );
 });

--- a/firmix_nodejs/packages/web-firmix/app/islands/ProjectListPage.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/islands/ProjectListPage.tsx
@@ -1,14 +1,14 @@
+import { createFC } from "@mx/auxiliaries/utils_fe_react/create_fc";
 import { ProjectListItemDto } from "@mx/web-firmix/app/base/types_dto";
 import { ProjectListItemCard } from "@mx/web-firmix/app/features/project_list/ProjectListItemCard";
 import { Stack } from "../../styled-system/jsx";
-import { createFCE } from "../common_styling/create_fce";
 
 type Props = {
   projects: ProjectListItemDto[];
   showPublicity: boolean;
 };
 
-export const ProjectListPage = createFCE<Props>(
+export const ProjectListPage = createFC<Props>(
   ({ projects, showPublicity }) => {
     return (
       <Stack gap={3} padding="16px 0">

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ React, TypeScript, MongoDBを共通で使っています。
 |パッケージ|対象サイト|構成|リリースURL
 |--|--|--|--|
 |web-firmix|Firmix|Remix, Panda CSS| -- |
-|web-firmix-nextjs|Firmix|NextJS, Panda CSS| firmix.nector.me |
+|web-firmix-nextjs|Firmix|Next.js, Panda CSS| firmix.nector.me |
 |web-kfx|KFX|Remix, Linaria| firmix-kfx.nector.me |
 
 Firmix(Base)のサイトの実装が2つあり、RemixとNextJSのどちらで今後開発を進めていくかまだ決まっていません。


### PR DESCRIPTION
Panda CSSの全Utility Propsをコンポーネントに渡せるようにしていますが、呼び出し側でどの値がコンポーネント自身のPropsかがわかりにくくなるため、これを廃止して、jsxqの`q prop`とPanda CSSの`css()`関数を使うように変更しました。