### PR TITLE
markdownの背景色を修正

### DIFF
--- a/firmix_nodejs/package-lock.json
+++ b/firmix_nodejs/package-lock.json
@@ -1579,7 +1579,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/firmix_nodejs/packages/web-firmix-nextjs/src/app/layout.tsx
+++ b/firmix_nodejs/packages/web-firmix-nextjs/src/app/layout.tsx
@@ -46,7 +46,7 @@ export default async function RootLayout({
         />
         <link
           rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown.min.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
           crossOrigin="anonymous"
         />
       </head>

--- a/firmix_nodejs/packages/web-firmix/app/root.tsx
+++ b/firmix_nodejs/packages/web-firmix/app/root.tsx
@@ -56,7 +56,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
         <link
           rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown.min.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
           crossOrigin="anonymous"
         />
         <Meta />

--- a/firmix_nodejs/packages/web-kfx/app/root.tsx
+++ b/firmix_nodejs/packages/web-kfx/app/root.tsx
@@ -56,7 +56,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
         <link
           rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown.min.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
           crossOrigin="anonymous"
         />
         <Meta />


### PR DESCRIPTION
OSのテーマがdarkのときに、ページ全体は白背景ベースのデザインだけれどmarkdownのコンテンツ部分が黒背景で表示されているので、OSのテーマによる可変を無効化して常にlightテーマでmarkdownが表示されるようにしました。